### PR TITLE
refer to mirage module types modules by new name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,16 +26,16 @@
 
 ## 1.2.2 (2013-12-08)
 
-* Use the `V1.KV_RO` signature from mirage-types>=0.5.0
+* Use the `Mirage_types.KV_RO` signature from mirage-types>=0.5.0
 * Add Travis CI scripts.
 
 ## 1.2.1 (2013-12-08)
 
-* Generate the correct signature for `V1.KV_RO`.
+* Generate the correct signature for `Mirage_types.KV_RO`.
 
 ## 1.2.0 (2013-12-08)
 
-* Use the `V1.KV_RO` signature from mirage-types>=0.3.0
+* Use the `Mirage_types.KV_RO` signature from mirage-types>=0.3.0
 
 ## 1.1.2 (2013-12-07)
 


### PR DESCRIPTION
V1 is now Mirage_types, and V1_LWT is now Mirage_types_lwt, as of MirageOS version 3.0.0.