### PR TITLE
Fix opam constraints over ocamlfind

### DIFF
--- a/opam
+++ b/opam
@@ -10,7 +10,7 @@ available:     [ ocaml-version >= "4.03.0" ]
 
 depends: [
   "cmdliner"
-  "ocamlfind" {build & test}
+  "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
   "bos" {test}


### PR DESCRIPTION
I encountered a compilation problem while installing crush and upgrading ocamlfind at the same time. The first one has been compiled before the second and as expected, it failed.

This is because the constraint ```build & test``` means ```this is a dependency only if tests are enabled and it doesn't need to be recompiled if ocamlfind is upgraded```.