### PR TITLE
Use `SOURCE_DATE_EPOCH` if set

### DIFF
--- a/src/crunch.ml
+++ b/src/crunch.ml
@@ -66,7 +66,11 @@ let chunk_info = Hashtbl.create 1
 let file_info = Hashtbl.create 1
 
 let output_generated_by oc binary =
-  let t = Unix.gettimeofday () in
+  let t =
+    try
+      float_of_string (Sys.getenv "SOURCE_DATE_EPOCH")
+    with Not_found ->
+      Unix.gettimeofday () in
   let months = [| "Jan"; "Feb"; "Mar"; "Apr"; "May"; "Jun";
                   "Jul"; "Aug"; "Sep"; "Oct"; "Nov"; "Dec" |] in
   let days = [| "Sun"; "Mon"; "Tue"; "Wed"; "Thu"; "Fri"; "Sat" |] in


### PR DESCRIPTION
It would be useful to easily support reproducible builds.