### PR TITLE
Include files with no extension iff no extension has been set

### DIFF
--- a/src/crunch.ml
+++ b/src/crunch.ml
@@ -50,7 +50,7 @@ let walk_directory_tree exts walkfn root_dir =
               walkfn root_dir (String.sub n 2 (String.length n - 2))
             in
             match get_extension ~file:f with
-            | None -> traverse ()
+            | None -> if exts = [] then traverse () else ()
             | Some e when filter_ext e -> traverse ()
             | Some _ -> ()
           end


### PR DESCRIPTION
Currently, files with no extension are always traversed.

This PR changes the behavior so that such files are
traversed if and only if no extension has been specified.

(Context: the tool was used to include all files with a
specific extension, but also included files with no
extension such as ".abc".)