### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/crunch.opam
+++ b/crunch.opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "cmdliner"
   "ptime"
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "lwt" {with-test}
   "mirage-kv-lwt" {with-test & >= "2.0.0"}
   "mirage-kv-mem" {with-test}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.