### PR TITLE
Open files in binary mode so buffers don't underread on Windows.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Pending
+
+* Open files in binary mode so buffers don't underread on Windows.
+  (@jonahbeckford)
+
 ## v3.2.0 (2019-12-14)
 
 * Make crunch reproducible: use a Map.Make(String) instead of Hashtbl.

--- a/src/crunch.ml
+++ b/src/crunch.ml
@@ -82,7 +82,7 @@ let scan_file (chunk_info, file_info) root name =
   let full_name = Filename.concat root name in
   let stats = Unix.stat full_name in
   let size = stats.Unix.st_size in
-  let fin = open_in full_name in
+  let fin = open_in_bin full_name in
   let buf = Buffer.create size in
   Buffer.add_channel buf fin size;
   let s = Buffer.contents buf in


### PR DESCRIPTION
### Problem

I ran into the [following error](https://github.com/diskuv/dkml-installer-ocaml/runs/5958846669?check_suite_focus=true#step:50:38962) on Windows:

```
# (cd _build/default/package/console/setup && "C:\Program Files\Git\usr\bin\env.exe" OCAMLRUNPARAM=b ocaml-crunch -m plain -o seven_z.ml assets-to-crunch)
# Generating seven_z.ml
# ocaml-crunch: internal error, uncaught exception:
#               End_of_file
#               Raised at Stdlib__buffer.add_channel in file "buffer.ml", line 273, characters 18-35
#               Called from Crunch.scan_file in file "src/crunch.ml", line 87, characters 2-33
#               Called from Crunch.walk_directory_tree.walk_dir.repeat in file "src/crunch.ml", line 49, characters 30-54
#               Called from Crunch.walk_directory_tree.walk_dir in file "src/crunch.ml", line 53, characters 17-25
#               Called from Stdlib__list.fold_left in file "list.ml", line 121, characters 24-34
#               Called from Main.walker in file "src/main.ml", line 50, characters 4-113
#               Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 25, characters 19-24
#               Called from Cmdliner.Term.run in file "cmdliner.ml", line 117, characters 32-39
```

after using crunch with a [very basic invocation](https://github.com/diskuv/dkml-install-api/blob/26358717c6b6c2e5207f9636818ff60aa18f8f84/package/console/setup/dune#L30)

### Cause

`Buffer.add_channel` will raise `End_of_file` if it does not read as much as was allocated. See https://github.com/ocaml/ocaml/blob/46c947827ec2f6d6da7fe5e195ae5dda1d2ad0c5/stdlib/buffer.ml#L271-L273

On Windows `open_in` will translate carriage returns and perhaps other characters.

### Solution

Switch to `open_in_bin`. With the changes in this PR my [tests worked](https://github.com/diskuv/dkml-installer-ocaml/runs/5959110292?check_suite_focus=true#step:51:38606)
