### PR TITLE
Silent flag, `hash` and `size` functions for the plain module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,9 @@
 
 * Open files in binary mode so buffers don't underread on Windows.
   (@jonahbeckford)
-* Always use Unix-style paths for path keys (#?? @MisterDA)
+* Always use Unix-style paths for path keys (#58, @MisterDA)
+* Add -s and --silent flags (#52, #60 @MisterDA)
+* Add `hash` and `size` functions to the plain module (#53, #60, @MisterDA)
 
 ## v3.2.0 (2019-12-14)
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ OPTIONS
        -o OUTPUT, --output=OUTPUT
            Output file for the OCaml module.
 
+       -s, --silent
+           Silent mode.
+
 COMMON OPTIONS
        --help[=FMT] (default=auto)
            Show this help in format FMT. The value FMT must be one of auto,

--- a/src/crunch.ml
+++ b/src/crunch.ml
@@ -17,7 +17,8 @@
 
 module SM = Map.Make (String)
 
-type t = string SM.t * string list SM.t
+type file_info = { chunk_digests : string list; file_digest : string }
+type t = string SM.t * file_info SM.t
 
 let make () = (SM.empty, SM.empty)
 
@@ -129,7 +130,13 @@ let scan_file (chunk_info, file_info) root name =
   in
   (* consume fills !rev_chunks as a side effect, so sequentialise this*)
   let ci = consume 0 chunk_info in
-  (ci, SM.add name (List.rev !rev_chunks) file_info)
+  let entry =
+    {
+      chunk_digests = List.rev !rev_chunks;
+      file_digest = Digest.(to_hex (string s));
+    }
+  in
+  (ci, SM.add name entry file_info)
 
 let output_implementation (chunk_info, file_info) oc =
   let pf fmt = Printf.fprintf oc fmt in
@@ -137,9 +144,9 @@ let output_implementation (chunk_info, file_info) oc =
   SM.iter (fun name chunk -> pf "  let d_%s = %S\n\n" name chunk) chunk_info;
   pf "  let file_chunks = function\n";
   SM.iter
-    (fun name chunks ->
+    (fun name { chunk_digests; _ } ->
       pf "    | %S | \"/%s\" -> Some [" name (String.escaped name);
-      List.iter (pf " d_%s;") chunks;
+      List.iter (pf " d_%s;") chunk_digests;
       pf " ]\n")
     file_info;
   pf "    | _ -> None\n\n";
@@ -148,8 +155,9 @@ let output_implementation (chunk_info, file_info) oc =
   pf "]\n";
   pf "end\n"
 
-let output_plain_skeleton_ml oc =
-  output_string oc
+let output_plain_skeleton_ml (_, file_info) oc =
+  let pf fmt = Printf.fprintf oc fmt in
+  pf
     {|
 let file_list = Internal.file_list
 
@@ -157,7 +165,15 @@ let read name =
   match Internal.file_chunks name with
   | None -> None
   | Some c -> Some (String.concat "" c)
-|}
+
+let hash = function
+|};
+  SM.iter
+    (fun name { file_digest; _ } ->
+      pf "  | %S | \"/%s\" -> Some \"%s\"\n" name (String.escaped name)
+        file_digest)
+    file_info;
+  pf "  | _ -> None\n"
 
 let output_lwt_skeleton_ml oc =
   let days, ps =

--- a/src/crunch.ml
+++ b/src/crunch.ml
@@ -17,7 +17,12 @@
 
 module SM = Map.Make (String)
 
-type file_info = { chunk_digests : string list; file_digest : string }
+type file_info = {
+  chunk_digests : string list;
+  file_digest : string;
+  size : int;
+}
+
 type t = string SM.t * file_info SM.t
 
 let make () = (SM.empty, SM.empty)
@@ -134,6 +139,7 @@ let scan_file (chunk_info, file_info) root name =
     {
       chunk_digests = List.rev !rev_chunks;
       file_digest = Digest.(to_hex (string s));
+      size = String.length s;
     }
   in
   (ci, SM.add name entry file_info)
@@ -172,6 +178,12 @@ let hash = function
     (fun name { file_digest; _ } ->
       pf "  | %S | \"/%s\" -> Some \"%s\"\n" name (String.escaped name)
         file_digest)
+    file_info;
+  pf "  | _ -> None\n\n";
+  pf "let size = function\n";
+  SM.iter
+    (fun name { size; _ } ->
+      pf "  | %S | \"/%s\" -> Some %d\n" name (String.escaped name) size)
     file_info;
   pf "  | _ -> None\n"
 

--- a/src/crunch.mli
+++ b/src/crunch.mli
@@ -39,7 +39,7 @@ val output_lwt_skeleton_ml : out_channel -> unit
 val output_lwt_skeleton_mli : out_channel -> unit
 (** Output the Lwt helpers. *)
 
-val output_plain_skeleton_ml : out_channel -> unit
+val output_plain_skeleton_ml : t -> out_channel -> unit
 (** Output a simple skeleton. *)
 
 val walk_directory_tree :

--- a/src/main.ml
+++ b/src/main.ml
@@ -40,7 +40,7 @@ let walker output mode dirs exts silent =
   Crunch.output_implementation t oc;
   (match mode with
   | `Lwt -> Crunch.output_lwt_skeleton_ml oc
-  | `Plain -> Crunch.output_plain_skeleton_ml oc);
+  | `Plain -> Crunch.output_plain_skeleton_ml t oc);
   close_out oc;
   match output with
   | Some f when Filename.check_suffix f ".ml" && mode = `Lwt ->

--- a/src/realpath.pre_413.ml
+++ b/src/realpath.pre_413.ml
@@ -7,10 +7,10 @@ let realpath p =
   in
   let normalize s = getchdir (getchdir s) in
   if Filename.is_relative p then
-    match try Some (Sys.is_directory p) with Sys_error _ -> None with
-    | None -> p
-    | Some true -> normalize p
-    | Some false -> (
+    match Sys.is_directory p with
+    | exception Sys_error _ -> p
+    | true -> normalize p
+    | false -> (
         let dir = normalize (Filename.dirname p) in
         match Filename.basename p with
         | "." -> dir

--- a/test/t1_plain.expected.ml
+++ b/test/t1_plain.expected.ml
@@ -37,3 +37,11 @@ let read name =
   match Internal.file_chunks name with
   | None -> None
   | Some c -> Some (String.concat "" c)
+
+let hash = function
+  | "a" | "/a" -> Some "d3b07384d113edec49eaa6238ad5ff00"
+  | "b" | "/b" -> Some "c157a79031e1c40f85931829bc5fc552"
+  | "c" | "/c" -> Some "82e32faa21d2c4c0586cb4dc786ff4f7"
+  | "d" | "/d" -> Some "410b329e18babf8919b0dda0faf97384"
+  | "e/f" | "/e/f" -> Some "ca5e5972335360438e6605eab714cc1c"
+  | _ -> None

--- a/test/t1_plain.expected.ml
+++ b/test/t1_plain.expected.ml
@@ -45,3 +45,11 @@ let hash = function
   | "d" | "/d" -> Some "410b329e18babf8919b0dda0faf97384"
   | "e/f" | "/e/f" -> Some "ca5e5972335360438e6605eab714cc1c"
   | _ -> None
+
+let size = function
+  | "a" | "/a" -> Some 4
+  | "b" | "/b" -> Some 4
+  | "c" | "/c" -> Some 4100
+  | "d" | "/d" -> Some 12300
+  | "e/f" | "/e/f" -> Some 11
+  | _ -> None


### PR DESCRIPTION
Last but not least! This adds a silent flag, `hash` and `size` functions for the plain module.
This adds a breaking change to the `crunch` library (a new parameter), but I suspect that people are rather using the `ocaml-crunch` executable.