### PR TITLE
Don't specify period ('.') in extension list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## unreleased
+
+* Fixed a regression in v3.3.0 where periods ('.') had to be specified
+  in the extention list. (#62, @MisterDA)
+
 ## v3.3.0 (2022-07-24)
 
 * Open files in binary mode so buffers don't underread on Windows.

--- a/src/crunch.ml
+++ b/src/crunch.ml
@@ -57,7 +57,7 @@ let walk_directory_tree t exts walkfn root_dir =
             (* If extension list is empty then let all through, otherwise white list *)
             match (exts, Filename.extension f) with
             | [], _ -> repeat (walkfn t root_dir name)
-            | exts, e when e <> "" && List.mem e exts ->
+            | exts, e when e <> "" && List.mem (String.sub e 1 (String.length e -1)) exts ->
                 repeat (walkfn t root_dir name)
             | _ -> repeat t)
     in


### PR DESCRIPTION
Filename.extension returns the leading period. The former
get_extension function did not. Fixes a regression in 3.3.0.

Fix #61.

(it's august, my time off, too lazy to add a regression test now)