### PR TITLE
use mirage-kv-mem with variants instead of functors

### DIFF
--- a/crunch.opam
+++ b/crunch.opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "2.5"}
   "lwt" {with-test}
   "mirage-kv" {with-test & >= "3.0.0"}
-  "mirage-kv-mem" {with-test & >= "3.0.0"}
+  "mirage-kv-mem" {with-test & >= "4.0.0"}
   "fmt" {with-test}
 ]
 conflicts: [

--- a/crunch.opam
+++ b/crunch.opam
@@ -20,6 +20,7 @@ depends: [
 ]
 conflicts: [
   "mirage-kv" {< "3.0.0"}
+  "mirage-kv-mem" {< "4.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/src/crunch.ml
+++ b/src/crunch.ml
@@ -190,6 +190,13 @@ let hash = function
   pf "  | _ -> None\n"
 
 let output_lwt_skeleton_ml oc =
+  let days, ps =
+    Ptime.Span.to_d_ps
+    @@ Ptime.to_span
+         (match Ptime.of_float_s (now ()) with
+         | None -> assert false
+         | Some x -> x)
+  in
   Printf.fprintf oc
     {|
 open Lwt
@@ -208,9 +215,9 @@ let add store name =
   | Error e -> Lwt.fail_with (Fmt.to_to_string pp_write_error e)
 
 let connect () =
-  connect () >>= fun store ->
+  connect ~now:(fun () -> Ptime.v (%d, %LdL)) () >>= fun store ->
   Lwt_list.iter_s (add store) Internal.file_list >|= fun () -> store
-|}
+|} days ps
 
 let output_lwt_skeleton_mli oc =
   Printf.fprintf oc {|include Mirage_kv.RO

--- a/src/crunch.ml
+++ b/src/crunch.ml
@@ -201,13 +201,7 @@ let output_lwt_skeleton_ml oc =
     {|
 open Lwt
 
-module C = struct
-  let now_d_ps () = (%d, %LdL)
-  let current_tz_offset_s () = None
-  let period_d_ps () = None
-end
-
-include Mirage_kv_mem.Make (C)
+include Mirage_kv_mem
 
 let file_content name =
   match Internal.file_chunks name with

--- a/src/crunch.ml
+++ b/src/crunch.ml
@@ -217,7 +217,8 @@ let add store name =
 let connect () =
   connect ~now:(fun () -> Ptime.v (%d, %LdL)) () >>= fun store ->
   Lwt_list.iter_s (add store) Internal.file_list >|= fun () -> store
-|} days ps
+|}
+    days ps
 
 let output_lwt_skeleton_mli oc =
   Printf.fprintf oc {|include Mirage_kv.RO

--- a/src/crunch.ml
+++ b/src/crunch.ml
@@ -190,13 +190,6 @@ let hash = function
   pf "  | _ -> None\n"
 
 let output_lwt_skeleton_ml oc =
-  let days, ps =
-    Ptime.Span.to_d_ps
-    @@ Ptime.to_span
-         (match Ptime.of_float_s (now ()) with
-         | None -> assert false
-         | Some x -> x)
-  in
   Printf.fprintf oc
     {|
 open Lwt
@@ -218,7 +211,6 @@ let connect () =
   connect () >>= fun store ->
   Lwt_list.iter_s (add store) Internal.file_list >|= fun () -> store
 |}
-    days ps
 
 let output_lwt_skeleton_mli oc =
   Printf.fprintf oc {|include Mirage_kv.RO

--- a/test/t1.expected.ml
+++ b/test/t1.expected.ml
@@ -47,5 +47,5 @@ let add store name =
   | Error e -> Lwt.fail_with (Fmt.to_to_string pp_write_error e)
 
 let connect () =
-  connect () >>= fun store ->
+  connect ~now:(fun () -> Ptime.v (0, 0L)) () >>= fun store ->
   Lwt_list.iter_s (add store) Internal.file_list >|= fun () -> store

--- a/test/t1.expected.ml
+++ b/test/t1.expected.ml
@@ -33,13 +33,7 @@ end
 
 open Lwt
 
-module C = struct
-  let now_d_ps () = (0, 0L)
-  let current_tz_offset_s () = None
-  let period_d_ps () = None
-end
-
-include Mirage_kv_mem.Make (C)
+include Mirage_kv_mem
 
 let file_content name =
   match Internal.file_chunks name with


### PR DESCRIPTION
CI will be green once https://github.com/ocaml/opam-repository/pull/27416 is merged