### PR TITLE
Add support for 0-block crunch.

### DIFF
--- a/src/crunch.ml
+++ b/src/crunch.ml
@@ -23,9 +23,14 @@ type file_info = {
   size : int;
 }
 
-type t = string SM.t * file_info SM.t
+type t = {
+  block_size : int;
+  chunks : string SM.t;
+  files : file_info SM.t;
+}
 
-let make () = (SM.empty, SM.empty)
+let make ?(block_size = 4096) () =
+  { block_size; chunks = SM.empty; files = SM.empty }
 
 module Filename = struct
   include Filename
@@ -103,7 +108,7 @@ let output_generated_by oc binary =
     date
 
 (** Generate a set of MD5 hashed blocks, abort on collision *)
-let scan_file (chunk_info, file_info) root name =
+let scan_file t root name =
   let full_name = Filename.concat root name in
   let stats = Unix.stat full_name in
   let size = stats.Unix.st_size in
@@ -113,30 +118,31 @@ let scan_file (chunk_info, file_info) root name =
   let s = Buffer.contents buf in
   close_in fin;
   let rev_chunks = ref [] in
-  let calc_chunk chunk_info b =
+  let calc_chunk chunks b =
     let digest = Digest.to_hex (Digest.string b) in
     rev_chunks := digest :: !rev_chunks;
-    match SM.find_opt digest chunk_info with
-    | None -> SM.add digest b chunk_info
+    match SM.find_opt digest chunks with
+    | None -> SM.add digest b chunks
     | Some cur ->
         if not (String.equal cur b) then
           failwith ("MD5 hash collision in file " ^ name)
-        else chunk_info
+        else chunks
   in
-  (* Split the file as a series of chunks, of size up to 4096 (to simulate reading sectors) *)
-  let sec = 4096 in
-  (* sector size *)
-  let rec consume idx chunk_info =
-    if idx = size then chunk_info (* EOF *)
+  (* Split the file as a series of chunks, of size up to [block_size] (to
+     simulate reading sectors). A non-positive [block_size] keeps each file as a
+     single chunk, so that [read] can return the string literal itself. *)
+  let sec = if t.block_size > 0 then t.block_size else max size 1 in
+  let rec consume idx chunks =
+    if idx = size then chunks (* EOF *)
     else if idx + sec < size then
-      let chunk_info' = calc_chunk chunk_info (String.sub s idx sec) in
-      consume (idx + sec) chunk_info'
+      let chunks = calc_chunk chunks (String.sub s idx sec) in
+      consume (idx + sec) chunks
     else
       (* final chunk, short *)
-      calc_chunk chunk_info (String.sub s idx (size - idx))
+      calc_chunk chunks (String.sub s idx (size - idx))
   in
   (* consume fills !rev_chunks as a side effect, so sequentialise this*)
-  let ci = consume 0 chunk_info in
+  let chunks = consume 0 t.chunks in
   let entry =
     {
       chunk_digests = List.rev !rev_chunks;
@@ -144,26 +150,26 @@ let scan_file (chunk_info, file_info) root name =
       size = String.length s;
     }
   in
-  (ci, SM.add name entry file_info)
+  { t with chunks; files = SM.add name entry t.files }
 
-let output_implementation (chunk_info, file_info) oc =
+let output_implementation { chunks; files; _ } oc =
   let pf fmt = Printf.fprintf oc fmt in
   pf "module Internal = struct\n";
-  SM.iter (fun name chunk -> pf "  let d_%s = %S\n\n" name chunk) chunk_info;
+  SM.iter (fun name chunk -> pf "  let d_%s = %S\n\n" name chunk) chunks;
   pf "  let file_chunks = function\n";
   SM.iter
     (fun name { chunk_digests; _ } ->
       pf "    | %S | \"/%s\" -> Some [" name (String.escaped name);
       List.iter (pf " d_%s;") chunk_digests;
       pf " ]\n")
-    file_info;
+    files;
   pf "    | _ -> None\n\n";
   pf "  let file_list = [ ";
-  SM.iter (fun name _ -> pf "%S; " name) file_info;
+  SM.iter (fun name _ -> pf "%S; " name) files;
   pf "]\n";
   pf "end\n"
 
-let output_plain_skeleton_ml (_, file_info) oc =
+let output_plain_skeleton_ml { files = file_info; _ } oc =
   let pf fmt = Printf.fprintf oc fmt in
   pf
     {|
@@ -172,6 +178,7 @@ let file_list = Internal.file_list
 let read name =
   match Internal.file_chunks name with
   | None -> None
+  | Some [ c ] -> Some c
   | Some c -> Some (String.concat "" c)
 
 let hash = function

--- a/src/crunch.ml
+++ b/src/crunch.ml
@@ -23,11 +23,7 @@ type file_info = {
   size : int;
 }
 
-type t = {
-  block_size : int;
-  chunks : string SM.t;
-  files : file_info SM.t;
-}
+type t = { block_size : int; chunks : string SM.t; files : file_info SM.t }
 
 let make ?(block_size = 4096) () =
   { block_size; chunks = SM.empty; files = SM.empty }

--- a/src/crunch.mli
+++ b/src/crunch.mli
@@ -20,8 +20,12 @@
 type t
 (** The type of a crunch. *)
 
-val make : unit -> t
-(** [make ()] is an empty crunch. *)
+val make : ?block_size:int -> unit -> t
+(** [make ()] is an empty crunch. Files are split into chunks of [block_size]
+    bytes (4096 by default). A non-positive [block_size] emits each file as a
+    single string literal: chunks are no longer deduplicated, but [read] returns
+    the literal without copying it, and the data stays demand-paged from the
+    executable instead of being pulled into memory by the GC's root scan. *)
 
 val output_generated_by : out_channel -> string -> unit
 (** [output_generated_by oc binary_name] generate a comments saying

--- a/src/main.ml
+++ b/src/main.ml
@@ -38,7 +38,8 @@ let walker output mode dirs exts block_size silent =
   let t =
     List.fold_left
       (fun t -> Crunch.walk_directory_tree t exts Crunch.scan_file)
-      (Crunch.make ~block_size ()) dirs
+      (Crunch.make ~block_size ())
+      dirs
   in
   Crunch.output_generated_by oc binary;
   Crunch.output_implementation t oc;

--- a/src/main.ml
+++ b/src/main.ml
@@ -21,7 +21,7 @@
    ["main"]. *)
 let binary = "ocaml-crunch"
 
-let walker output mode dirs exts silent =
+let walker output mode dirs exts block_size silent =
   let log fmt =
     if silent then Printf.ifprintf stdout fmt
     else Printf.fprintf stdout (fmt ^^ "%!")
@@ -38,7 +38,7 @@ let walker output mode dirs exts silent =
   let t =
     List.fold_left
       (fun t -> Crunch.walk_directory_tree t exts Crunch.scan_file)
-      (Crunch.make ()) dirs
+      (Crunch.make ~block_size ()) dirs
   in
   Crunch.output_generated_by oc binary;
   Crunch.output_implementation t oc;
@@ -94,8 +94,22 @@ let () =
              crunched output. If not specified, then all files will be \
              crunched into the output module.")
   in
+  let block_size =
+    Arg.(
+      value & opt int 4096
+      & info [ "b"; "block-size" ] ~docv:"BLOCK SIZE"
+          ~doc:
+            "Size of the chunks files are split into. Identical chunks are \
+             emitted only once. Use $(b,0) to emit each file as a single \
+             string literal instead: the generated module is bigger, but \
+             $(b,read) returns the literal without copying it and the data \
+             stays demand-paged from the executable rather than being faulted \
+             in wholesale by the GC.")
+  in
   let quiet = Arg.(value & flag & info [ "s"; "silent" ] ~doc:"Silent mode.") in
-  let cmd_t = Term.(const walker $ output $ mode $ dirs $ exts $ quiet) in
+  let cmd_t =
+    Term.(const walker $ output $ mode $ dirs $ exts $ block_size $ quiet)
+  in
   let info =
     let doc =
       "Convert a directory structure into a standalone OCaml module that can \

--- a/test/t1_plain.expected.ml
+++ b/test/t1_plain.expected.ml
@@ -36,6 +36,7 @@ let file_list = Internal.file_list
 let read name =
   match Internal.file_chunks name with
   | None -> None
+  | Some [ c ] -> Some c
   | Some c -> Some (String.concat "" c)
 
 let hash = function

--- a/test/t1_plain_ext.expected.ml
+++ b/test/t1_plain_ext.expected.ml
@@ -16,6 +16,7 @@ let file_list = Internal.file_list
 let read name =
   match Internal.file_chunks name with
   | None -> None
+  | Some [ c ] -> Some c
   | Some c -> Some (String.concat "" c)
 
 let hash = function


### PR DESCRIPTION
This PR adds an optional chunk size when crunching data (`-b`/`--block-size`, default 4096 — unchanged), where `0` emits each file as a single string literal.

Files are currently split into 4096-byte chunks, each emitted as its own top-level binding. For large embedded datasets this has two costs at runtime:

- The OCaml major GC scans global roots, so it touches a header word in every one of those bindings — i.e. in every page of the embedded data. The first full major collection puts the whole dataset into RSS and it stays there, even if the program never reads a single file.
- `read` does `String.concat "" chunks`, allocating a full heap copy of each file it returns.

With `-b 0` there is a single literal per file, so nothing for the root scan to walk into and nothing to concatenate: `read` returns the literal itself (new `| Some [ c ] -> Some c` case, which also helps small files at the default block size), and the data stays demand-paged from the executable. Only the pages actually read are faulted in.

Measured on a 26 MB data tree (Camomile's Unicode data), same program, native compilation:

| | startup RSS | after 3 full major GCs | binary |
|---|---|---|---|
| 4096-byte chunks | 3.0 MB | 21.4 MB | 21.4 MB |
| `-b 0` | 2.5 MB | 5.5 MB | 21.3 MB |

The tradeoff is that identical chunks are no longer deduplicated. On that dataset the generated source grew 3.5% and the binary was 155 KB smaller; datasets with genuinely repetitive content would fare worse, which is why the default is unchanged.

`Crunch.make` gains a `?block_size` argument and `type t` became a record.